### PR TITLE
Call remove on view when removing form cache

### DIFF
--- a/backbone.viewcache.js
+++ b/backbone.viewcache.js
@@ -79,6 +79,7 @@
   }
 
   function removeFromCache(key) {
+    cachedViews[key].remove();
     delete cachedViews[key];
   }
 


### PR DESCRIPTION
By using Backbone's remove method, this cleans up the dom bindings and event listeners before losing the reference.
