### PR TITLE
Prevent implicit overwrite of previous cacheExpiry

### DIFF
--- a/backbone.viewcache.js
+++ b/backbone.viewcache.js
@@ -153,10 +153,15 @@
 
     // Sets a view into the cache using the current URL fragment.
     // If a URL fragment is passed, it will be used instead.
+    //
+    // Maintains previously set cache expiration time unless
+    // forceCacheUpdate is used.
     // Returns the view.
-    set: function(view, fragment) {
+    set: function(view, fragment, forceCacheUpdate) {
       fragment = getFragment(fragment);
-      view.setCacheExpiry(config.cacheExpiry);
+      if (forceCacheUpdate || _.isUndefined(view._cacheExpiry)) {
+        view.setCacheExpiry(config.cacheExpiry);
+      }
       if (expirySet) setClearExpiredsTime();
       cachedViews[fragment] = view;
       return view;


### PR DESCRIPTION
Prevent overwriting a view's `_cacheExpiry` if it has already been set elsewhere, especially by the view itself. Still provide a mechanism to force the expiration update. This is a breaking change to the previous functionality of allowing `set` to always override the previous cache expire.
